### PR TITLE
refactor: Remove "Newsletter" and "Team" from navigation

### DIFF
--- a/404.html
+++ b/404.html
@@ -103,17 +103,9 @@
                                             <li><a href="service.html">Single service</a></li>
                                         </ul>
                                     </li>
-                                    <li class="mil-has-children">
-                                        <a href="#.">Newsletter</a>
-                                        <ul>
-                                            <li><a href="blog.html">Blog List</a></li>
-                                            <li><a href="publication.html">Publication</a></li>
-                                        </ul>
-                                    </li>
                                     <li class="mil-has-children mil-active">
                                         <a href="#.">Other pages</a>
                                         <ul>
-                                            <li><a href="team.html">Team</a></li>
                                             <li><a href="contact.html">Contact</a></li>
                                             <li><a href="404.html">404</a></li>
                                         </ul>

--- a/contact.html
+++ b/contact.html
@@ -103,17 +103,9 @@
                                             <li><a href="service.html">Single service</a></li>
                                         </ul>
                                     </li>
-                                    <li class="mil-has-children">
-                                        <a href="#.">Newsletter</a>
-                                        <ul>
-                                            <li><a href="blog.html">Blog List</a></li>
-                                            <li><a href="publication.html">Publication</a></li>
-                                        </ul>
-                                    </li>
                                     <li class="mil-has-children mil-active">
                                         <a href="#.">Other pages</a>
                                         <ul>
-                                            <li><a href="team.html">Team</a></li>
                                             <li><a href="contact.html">Contact</a></li>
                                             <li><a href="404.html">404</a></li>
                                         </ul>

--- a/home-1.html
+++ b/home-1.html
@@ -104,16 +104,8 @@
                                         </ul>
                                     </li>
                                     <li class="mil-has-children">
-                                        <a href="#.">Newsletter</a>
-                                        <ul>
-                                            <li><a href="blog.html">Blog List</a></li>
-                                            <li><a href="publication.html">Publication</a></li>
-                                        </ul>
-                                    </li>
-                                    <li class="mil-has-children">
                                         <a href="#.">Other pages</a>
                                         <ul>
-                                            <li><a href="team.html">Team</a></li>
                                             <li><a href="contact.html">Contact</a></li>
                                             <li><a href="404.html">404</a></li>
                                         </ul>

--- a/project-4.html
+++ b/project-4.html
@@ -103,17 +103,9 @@
                                             <li><a href="service.html">Single service</a></li>
                                         </ul>
                                     </li>
-                                    <li class="mil-has-children">
-                                        <a href="#.">Newsletter</a>
-                                        <ul>
-                                            <li><a href="blog.html">Blog List</a></li>
-                                            <li><a href="publication.html">Publication</a></li>
-                                        </ul>
-                                    </li>
                                     <li class="mil-has-children mil-active">
                                         <a href="#.">Other pages</a>
                                         <ul>
-                                            <li><a href="team.html">Team</a></li>
                                             <li><a href="contact.html">Contact</a></li>
                                             <li><a href="404.html">404</a></li>
                                         </ul>

--- a/project-5.html
+++ b/project-5.html
@@ -103,17 +103,9 @@
                                             <li><a href="service.html">Single service</a></li>
                                         </ul>
                                     </li>
-                                    <li class="mil-has-children">
-                                        <a href="#.">Newsletter</a>
-                                        <ul>
-                                            <li><a href="blog.html">Blog List</a></li>
-                                            <li><a href="publication.html">Publication</a></li>
-                                        </ul>
-                                    </li>
                                     <li class="mil-has-children mil-active">
                                         <a href="#.">Other pages</a>
                                         <ul>
-                                            <li><a href="team.html">Team</a></li>
                                             <li><a href="contact.html">Contact</a></li>
                                             <li><a href="404.html">404</a></li>
                                         </ul>

--- a/project-6.html
+++ b/project-6.html
@@ -103,17 +103,9 @@
                                             <li><a href="service.html">Single service</a></li>
                                         </ul>
                                     </li>
-                                    <li class="mil-has-children">
-                                        <a href="#.">Newsletter</a>
-                                        <ul>
-                                            <li><a href="blog.html">Blog List</a></li>
-                                            <li><a href="publication.html">Publication</a></li>
-                                        </ul>
-                                    </li>
                                     <li class="mil-has-children mil-active">
                                         <a href="#.">Other pages</a>
                                         <ul>
-                                            <li><a href="team.html">Team</a></li>
                                             <li><a href="contact.html">Contact</a></li>
                                             <li><a href="404.html">404</a></li>
                                         </ul>

--- a/service.html
+++ b/service.html
@@ -104,16 +104,8 @@
                                         </ul>
                                     </li>
                                     <li class="mil-has-children">
-                                        <a href="#.">Newsletter</a>
-                                        <ul>
-                                            <li><a href="blog.html">Blog List</a></li>
-                                            <li><a href="publication.html">Publication</a></li>
-                                        </ul>
-                                    </li>
-                                    <li class="mil-has-children">
                                         <a href="#.">Other pages</a>
                                         <ul>
-                                            <li><a href="team.html">Team</a></li>
                                             <li><a href="contact.html">Contact</a></li>
                                             <li><a href="404.html">404</a></li>
                                         </ul>

--- a/services.html
+++ b/services.html
@@ -104,16 +104,8 @@
                                         </ul>
                                     </li>
                                     <li class="mil-has-children">
-                                        <a href="#.">Newsletter</a>
-                                        <ul>
-                                            <li><a href="blog.html">Blog List</a></li>
-                                            <li><a href="publication.html">Publication</a></li>
-                                        </ul>
-                                    </li>
-                                    <li class="mil-has-children">
                                         <a href="#.">Other pages</a>
                                         <ul>
-                                            <li><a href="team.html">Team</a></li>
                                             <li><a href="contact.html">Contact</a></li>
                                             <li><a href="404.html">404</a></li>
                                         </ul>


### PR DESCRIPTION
Removes the "Newsletter" and "Team" links from the main navigation menu. This change is applied consistently across all relevant HTML files to ensure a uniform navigation structure throughout the static site.